### PR TITLE
Remove usage of deprecated 'org.sonar.check.Cardinality'

### DIFF
--- a/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaRulesDefinition.java
+++ b/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaRulesDefinition.java
@@ -36,7 +36,6 @@ import org.sonar.api.server.debt.DebtRemediationFunction;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionAnnotationLoader;
 import org.sonar.api.utils.AnnotationUtils;
-import org.sonar.check.Cardinality;
 import org.sonar.plugins.java.Java;
 import org.sonar.squidbridge.annotations.RuleTemplate;
 
@@ -86,9 +85,6 @@ public class MyJavaRulesDefinition implements RulesDefinition {
     ruleMetadata(rule);
 
     rule.setTemplate(AnnotationUtils.getAnnotation(ruleClass, RuleTemplate.class) != null);
-    if (ruleAnnotation.cardinality() == Cardinality.MULTIPLE) {
-      throw new IllegalArgumentException("Cardinality is not supported, use the RuleTemplate annotation instead for " + ruleClass);
-    }
   }
 
   private void ruleMetadata(NewRule rule) {


### PR DESCRIPTION
Fix according to removal of class `org.sonar.check.Cardinality` in [SONAR-10235](https://jira.sonarsource.com/browse/SONAR-10235).