### PR TITLE
Add requirePlugins metadata to the Java custom rule sample

### DIFF
--- a/java-custom-rules/pom.xml
+++ b/java-custom-rules/pom.xml
@@ -135,6 +135,7 @@
 					<pluginClass>org.sonar.samples.java.MyJavaRulesPlugin</pluginClass>
 					<sonarLintSupported>true</sonarLintSupported>
 					<sonarQubeMinVersion>6.7</sonarQubeMinVersion>
+					<requirePlugins>java:${sonarjava.version}</requirePlugins>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
This is necessary to let SonarLint properly skip the loading of the custom plugin when SonarJava is not loaded (for example on VSCode).